### PR TITLE
Switch dependency from saz/rsyslog to puppet/rsyslog

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -126,11 +126,7 @@ class bind::common {
     }
 
     # Adapt syslog configuration
-    if ! defined(Class['rsyslog::client']) {
-        class { 'rsyslog::client': }
-    }
-    rsyslog::snippet { 'bind-chroot':
-        ensure  => $bind::ensure,
+    rsyslog::component::custom_config { 'bind-chroot':
         content => template('bind/rsyslog.conf.erb'),
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -25,8 +25,8 @@
       "version_requirement": ">=1.1.0"
     },
     {
-      "name": "saz/rsyslog",
-      "version_requirement": ">=5.0.0"
+      "name": "puppet/rsyslog",
+      "version_requirement": ">=4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
The module saz/rsyslog is marked for deprecation, switch to puppet/rsyslog.